### PR TITLE
10進数を2,16進数に変換する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 ### How to run tests  
 Example:
 ```
-python -m pytest tests/test_radix_converter.py 
+pytest 
 ```

--- a/pybit/radix_convert.py
+++ b/pybit/radix_convert.py
@@ -1,14 +1,20 @@
 class RadixConvert:
 
     @staticmethod
-    def dec_to_bin(value: int) -> str:
+    def dec_to_bin(value: int, digits: int = 0) -> str:
         """
         Convert decimal number to binary.
         TODO: allow negative decimal
         :param value: (int) Decimal number.
+        :param digits: (int) Number of digits.
         :return: (str) Binary number
         """
-        return bin(value)
+        binary = ''
+        if value >= 0:
+            binary = '{0:#0{1}b}'.format(value, digits + 2)
+        else:
+            binary = '{:#0{}b}'.format(value, digits)
+        return binary
 
     @staticmethod
     def dec_to_hex(value: int) -> str:

--- a/pybit/radix_convert.py
+++ b/pybit/radix_convert.py
@@ -13,15 +13,23 @@ class RadixConvert:
             binary = '{0:#0{1}b}'.format(value, digits + 2)
         else:
             # Calc 2s compliment and mask bits for designated digits
-            binary = bin(((-value ^ 0b111111111111) + 0b1) & 2**digits-1)
+            binary = bin(((-value ^ (2 ** 32 - 1)) + 0b1) & 2 ** digits - 1)
         return binary
 
     @staticmethod
-    def dec_to_hex(value: int) -> str:
+    def dec_to_hex(value: int, digits: int = 0) -> str:
         """
         Convert decimal number to hexadecimal number.
         TODO: allow negative decimal
         :param value: (int) Decimal number.
+        :param digits: (int) Number of digits.
         :return: (str) Hexadecimal number
         """
-        return hex(value)
+        hexadecimal = ''
+        if value >= 0:
+            hexadecimal = '{0:#0{1}x}'.format(value, digits + 2)
+        else:
+            digits *= 4
+            # Calc 2s compliment and mask bits for designated digits
+            hexadecimal = hex(((-value ^ (2 ** 32 - 1)) + 0b1) & 2 ** digits - 1)
+        return hexadecimal

--- a/pybit/radix_convert.py
+++ b/pybit/radix_convert.py
@@ -4,7 +4,6 @@ class RadixConvert:
     def dec_to_bin(value: int, digits: int = 0) -> str:
         """
         Convert decimal number to binary.
-        TODO: allow negative decimal
         :param value: (int) Decimal number.
         :param digits: (int) Number of digits.
         :return: (str) Binary number
@@ -13,7 +12,8 @@ class RadixConvert:
         if value >= 0:
             binary = '{0:#0{1}b}'.format(value, digits + 2)
         else:
-            binary = '{:#0{}b}'.format(value, digits)
+            # Calc 2s compliment and mask bits for designated digits
+            binary = bin(((-value ^ 0b111111111111) + 0b1) & 2**digits-1)
         return binary
 
     @staticmethod

--- a/tests/test_radix_converter.py
+++ b/tests/test_radix_converter.py
@@ -5,6 +5,7 @@ from pybit.radix_convert import RadixConvert
 def test_dec_to_bin():
     assert RadixConvert.dec_to_bin(0) == '0b0'
     assert RadixConvert.dec_to_bin(10) == '0b1010'
+    assert RadixConvert.dec_to_bin(10,5) == '0b01010'
     assert RadixConvert.dec_to_bin(100) == '0b1100100'
 
 

--- a/tests/test_radix_converter.py
+++ b/tests/test_radix_converter.py
@@ -15,3 +15,7 @@ def test_dec_to_hex():
     assert RadixConvert.dec_to_hex(0) == '0x0'
     assert RadixConvert.dec_to_hex(10) == '0xa'
     assert RadixConvert.dec_to_hex(100) == '0x64'
+    assert RadixConvert.dec_to_hex(100,4) == '0x0064'
+    assert RadixConvert.dec_to_hex(-100,2) == '0x9c'
+    assert RadixConvert.dec_to_hex(-100,4) == '0xff9c'
+    assert RadixConvert.dec_to_hex(-100,8) == '0xffffff9c'

--- a/tests/test_radix_converter.py
+++ b/tests/test_radix_converter.py
@@ -5,8 +5,10 @@ from pybit.radix_convert import RadixConvert
 def test_dec_to_bin():
     assert RadixConvert.dec_to_bin(0) == '0b0'
     assert RadixConvert.dec_to_bin(10) == '0b1010'
-    assert RadixConvert.dec_to_bin(10,5) == '0b01010'
+    assert RadixConvert.dec_to_bin(10,10) == '0b0000001010'
     assert RadixConvert.dec_to_bin(100) == '0b1100100'
+    assert RadixConvert.dec_to_bin(-10,5) == '0b10110'
+    assert RadixConvert.dec_to_bin(-100,8) == '0b10011100'
 
 
 def test_dec_to_hex():


### PR DESCRIPTION
`dec_to_bin()`と`dec_to_hex()`で基底返還できるようにした。
それぞれの引数に10進数の値と基底変換後の値の桁数を指定すると文字列型で値が返される。
10進数が負数の場合にも対応した。