### PR TITLE
論理シフト，算術シフトの実装

### DIFF
--- a/pybit/bits.py
+++ b/pybit/bits.py
@@ -75,7 +75,7 @@ class Bits:
         if t == 'l' or t == 'logic':
             return Bits([0 for _ in range(min(n, size))] + self.bits[:max(size - n, 0)])
         elif t == 'a' or t == 'arithmetic':
-            msb = self.bits[size-1]
+            msb = self.bits[0]
             return Bits([msb for _ in range(min(n, size))] + self.bits[:max(size - n, 0)])
         else:
             raise TypeError('shift type must be logical or arithmetic')
@@ -87,7 +87,7 @@ class Bits:
         if t == 'l' or t == 'logic':
             return Bits(lst[n:])
         elif t == 'a' or t == 'arithmetic':
-            msb = self.bits[size - 1]
-            return Bits([msb]+lst[n+1:])
+            msb = self.bits[0]
+            return Bits([msb] + lst[n + 1:])
         else:
             raise TypeError('shift type must be logical or arithmetic')

--- a/pybit/bits.py
+++ b/pybit/bits.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 
 class BitsError(Exception):
@@ -25,29 +25,29 @@ class Bits:
                 self.bits = [0 for x in range(size)]
             else:
                 raise BitsConstructError('size must be specified')
-    
+
     def __getitem__(self, key: int) -> int:
         return self.bits[key]
-    
+
     def __setitem__(self, key: int, val: int) -> int:
         self.bits[key] = val
-    
+
     def __len__(self) -> int:
         return len(self.bits)
 
     def _check_len_eq(self, o: 'Bits') -> None:
         if len(self) != len(o):
             raise BitsOperationError('Bits length does not match')
-    
+
     def __eq__(self, o) -> bool:
         if isinstance(o, Bits):
             self._check_len_eq(o)
             return all([a == b for a, b in zip(self.bits, o.bits)])
         return False
-    
+
     def __ne__(self, o) -> bool:
         return not self.__eq__(o)
-    
+
     def __and__(self, o: 'Bits') -> 'Bits':
         if isinstance(o, Bits):
             self._check_len_eq(o)
@@ -68,3 +68,26 @@ class Bits:
 
     def __invert__(self) -> 'Bits':
         return Bits([1 - x for x in self.bits])
+
+    def __rshift__(self, arg: Tuple[str, int]) -> 'Bits':
+        t, n = arg
+        size = len(self.bits)
+        if t == 'l' or t == 'logic':
+            return Bits([0 for _ in range(min(n, size))] + self.bits[:max(size - n, 0)])
+        elif t == 'a' or t == 'arithmetic':
+            msb = self.bits[size-1]
+            return Bits([msb for _ in range(min(n, size))] + self.bits[:max(size - n, 0)])
+        else:
+            raise TypeError('shift type must be logical or arithmetic')
+
+    def __lshift__(self, arg: Tuple[str, int]) -> 'Bits':
+        t, n = arg
+        size = len(self.bits)
+        lst = self.bits + [0 for _ in range(n)]
+        if t == 'l' or t == 'logic':
+            return Bits(lst[n:])
+        elif t == 'a' or t == 'arithmetic':
+            msb = self.bits[size - 1]
+            return Bits([msb]+lst[n+1:])
+        else:
+            raise TypeError('shift type must be logical or arithmetic')

--- a/tests/test_bits.py
+++ b/tests/test_bits.py
@@ -108,7 +108,7 @@ def test_bits_left_logical_shift():
 
 def test_bits_right_arithmetic_shift():
     bits = Bits([1, 1, 0, 1])
-    bits2 = Bits([1, 0, 1, 1, 0, 1])
+    bits2 = Bits([1, 0, 1, 1, 0, 0])
     assert bits >> ('a', 0) == Bits([1, 1, 0, 1])
     assert bits >> ('a', 1) == Bits([1, 1, 1, 0])
     assert bits >> ('a', 2) == Bits([1, 1, 1, 1])
@@ -120,14 +120,14 @@ def test_bits_right_arithmetic_shift():
 
 def test_bits_left_arithmetic_shift():
     bits = Bits([1, 1, 0, 1])
-    bits2 = Bits([1, 0, 1, 1, 0, 1])
+    bits2 = Bits([1, 0, 1, 1, 0, 0])
     assert bits << ('a', 0) == Bits([1, 1, 0, 1])
     assert bits << ('a', 1) == Bits([1, 0, 1, 0])
     assert bits << ('a', 2) == Bits([1, 1, 0, 0])
     assert bits << ('a', 3) == Bits([1, 0, 0, 0])
     assert bits << ('a', 4) == Bits([1, 0, 0, 0])
     assert bits << ('a', 5) == Bits([1, 0, 0, 0])
-    assert bits2 << ('a', 1) == Bits([1, 1, 1, 0, 1, 0])
-    assert bits2 << ('a', 2) == Bits([1, 1, 0, 1, 0, 0])
-    assert bits2 << ('a', 3) == Bits([1, 0, 1, 0, 0, 0])
-    assert Bits([1, 1, 1, 0, 1, 1, 0, 1]) << ('a', 2) == Bits([1, 0, 1, 1, 0, 1, 0, 0])
+    assert bits2 << ('a', 1) == Bits([1, 1, 1, 0, 0, 0])
+    assert bits2 << ('a', 2) == Bits([1, 1, 0, 0, 0, 0])
+    assert bits2 << ('a', 3) == Bits([1, 0, 0, 0, 0, 0])
+    assert Bits([1, 1, 1, 0, 1, 1, 0, 0]) << ('a', 2) == Bits([1, 0, 1, 1, 0, 0, 0, 0])

--- a/tests/test_bits.py
+++ b/tests/test_bits.py
@@ -87,3 +87,47 @@ def test_bits_and_different_len():
     bits2 = Bits([1, 0, 0, 1, 0])
     with pytest.raises(BitsOperationError):
         bits1 ^ bits2
+
+def test_bits_right_logical_shift():
+    bits = Bits([1, 1, 0, 1])
+    assert bits >> ('l', 0) == Bits([1, 1, 0, 1])
+    assert bits >> ('l', 1) == Bits([0, 1, 1, 0])
+    assert bits >> ('l', 2) == Bits([0, 0, 1, 1])
+    assert bits >> ('l', 3) == Bits([0, 0, 0, 1])
+    assert bits >> ('l', 4) == Bits([0, 0, 0, 0])
+    assert bits >> ('l', 5) == Bits([0, 0, 0, 0])
+
+def test_bits_left_logical_shift():
+    bits = Bits([1, 1, 0, 1])
+    assert bits << ('l', 0) == Bits([1, 1, 0, 1])
+    assert bits << ('l', 1) == Bits([1, 0, 1, 0])
+    assert bits << ('l', 2) == Bits([0, 1, 0, 0])
+    assert bits << ('l', 3) == Bits([1, 0, 0, 0])
+    assert bits << ('l', 4) == Bits([0, 0, 0, 0])
+    assert bits << ('l', 5) == Bits([0, 0, 0, 0])
+
+def test_bits_right_arithmetic_shift():
+    bits = Bits([1, 1, 0, 1])
+    bits2 = Bits([1, 0, 1, 1, 0, 1])
+    assert bits >> ('a', 0) == Bits([1, 1, 0, 1])
+    assert bits >> ('a', 1) == Bits([1, 1, 1, 0])
+    assert bits >> ('a', 2) == Bits([1, 1, 1, 1])
+    assert bits >> ('a', 3) == Bits([1, 1, 1, 1])
+    assert bits >> ('a', 4) == Bits([1, 1, 1, 1])
+    assert bits2 >> ('a', 1) == Bits([1, 1, 0, 1, 1, 0])
+    assert bits2 >> ('a', 2) == Bits([1, 1, 1, 0, 1, 1])
+    assert bits2 >> ('a', 3) == Bits([1, 1, 1, 1, 0, 1])
+
+def test_bits_left_arithmetic_shift():
+    bits = Bits([1, 1, 0, 1])
+    bits2 = Bits([1, 0, 1, 1, 0, 1])
+    assert bits << ('a', 0) == Bits([1, 1, 0, 1])
+    assert bits << ('a', 1) == Bits([1, 0, 1, 0])
+    assert bits << ('a', 2) == Bits([1, 1, 0, 0])
+    assert bits << ('a', 3) == Bits([1, 0, 0, 0])
+    assert bits << ('a', 4) == Bits([1, 0, 0, 0])
+    assert bits << ('a', 5) == Bits([1, 0, 0, 0])
+    assert bits2 << ('a', 1) == Bits([1, 1, 1, 0, 1, 0])
+    assert bits2 << ('a', 2) == Bits([1, 1, 0, 1, 0, 0])
+    assert bits2 << ('a', 3) == Bits([1, 0, 1, 0, 0, 0])
+    assert Bits([1, 1, 1, 0, 1, 1, 0, 1]) << ('a', 2) == Bits([1, 0, 1, 1, 0, 1, 0, 0])


### PR DESCRIPTION
- 右シフト
    - 論理シフト： `bits >> ('l', 2) `
    - 算術シフト： `bits >> ('a', 2) `
- 左シフト
    - 論理シフト： `bits << ('l', 2) `
    - 算術シフト： `bits << ('a', 2) `

シフトタイプとシフト量のタプルは入れ替えてもいいかも
Resolve #5 